### PR TITLE
Exporting Reactives as well

### DIFF
--- a/lib/scoped.dart
+++ b/lib/scoped.dart
@@ -3,9 +3,8 @@ library scoped;
 export 'package:scoped/src/store.dart';
 export 'package:scoped/src/scope.dart';
 export 'package:scoped/src/reactive.dart';
+export 'package:scoped/src/reactives.dart';
 export 'package:scoped/src/ref.dart';
 export 'package:scoped/src/refs.dart';
-
 export 'package:scoped/src/bond.dart';
-
 export 'package:scoped/src/extension.dart';


### PR DESCRIPTION
Version 2.0.1 forgot to export `scoped/src/reactives.dart`, which is important to replace `FluidsBuilder` cases, for instance.